### PR TITLE
[chore] Update actions/cache to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
           node-version: 12.x
 
       - name: Use cached node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: nodeModules-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
v2 is out of date and workflows will fail from Feb 2025. v4 is the latest version