### PR TITLE
[fix] Trim timestamp lines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@veedstudio/subtitle",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@veedstudio/subtitle",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "license": "MIT",
       "dependencies": {
         "strip-bom": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veedstudio/subtitle",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Library for parsing and manipulating subtitles",
   "repository": {
     "type": "git",

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -34,7 +34,7 @@ export class Parser {
   }
 
   private isTimestamp(line: string): boolean {
-    return RE_TIMESTAMP.test(line)
+    return RE_TIMESTAMP.test(line.trim())
   }
 
   private isVttComment(line: string): boolean {

--- a/src/parseTimestamps.ts
+++ b/src/parseTimestamps.ts
@@ -4,7 +4,7 @@ import { Timestamp } from './types'
 export const RE_TIMESTAMP = /^((?:\d{1,}:)?\d{1,2}:\d{1,2}[,.]\d{1,3}) --> ((?:\d{1,}:)?\d{1,2}:\d{1,2}[,.]\d{1,3})(?: (.*))?$/
 
 export function parseTimestamps(value: string): Timestamp {
-  const match = RE_TIMESTAMP.exec(value)
+  const match = RE_TIMESTAMP.exec(value.trim())
 
   if (!match) {
     throw new Error('Invalid timestamp format')


### PR DESCRIPTION
SRT files that have whitespace in timestamp lines fail to parse as expected as it doesn't match the regex for timestamp line
It ends up looking like this in our app:
<img width="422" alt="image" src="https://github.com/user-attachments/assets/ebea7ec2-ff19-4e92-8e33-34c9734c11f7" />

This PR will trim the line upon checking isTimestamp and when checking against the regex for timestamp format

I didn't apply .trim on each line as I'm not sure if that's what we want or need, this fixes the issue that the user has

I tested by building the package and replacing it in my main app node_modules

Before:
<img width="1652" alt="image" src="https://github.com/user-attachments/assets/bd390864-3711-4bdb-a9d4-90ee397c1d4d" />

After:
<img width="1227" alt="image" src="https://github.com/user-attachments/assets/c98babde-93e2-4048-9020-b446a45de1d4" />


